### PR TITLE
dspy-ai 2.4.13 ❄️ 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,2 @@
 upload_channels:
   - sfe1ed40
-channels:
-  - https://staging.continuum.io/prefect/fs/structlog-feedstock/pr3/4b53cdc

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,4 @@
 upload_channels:
   - sfe1ed40
+channels:
+  - https://staging.continuum.io/prefect/fs/structlog-feedstock/pr3/54a1833

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
 upload_channels:
   - sfe1ed40
 channels:
-  - https://staging.continuum.io/prefect/fs/structlog-feedstock/pr3/54a1833
+  - https://staging.continuum.io/prefect/fs/structlog-feedstock/pr3/4b53cdc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,8 @@ requirements:
     - requests
     - optuna
     - pydantic >=2.0,<3.0
-    - structlog
+    # Previous versions of structlog are missing processors.CallsiteParameterAdder
+    - structlog >=22.1
     - jinja2
   run_constrained:
     - anthropic >=0.18.0,<0.19.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,8 @@ requirements:
     - wheel
   run:
     - python
-    - backoff >=2.2.1,<2.3
-    - joblib >=1.3,<2.0
+    - backoff >=2.2,<3.0a0
+    - joblib >=1.3,<2.0a0
     - openai >=0.28.1,<2.0.0
     - pandas
     - regex
@@ -32,19 +32,20 @@ requirements:
     - datasets >=2.14.6,<3.0.0
     - requests
     - optuna
-    - pydantic >=2.0,<3.0
+    - pydantic >=2.0,<3.0a0
     # Previous versions of structlog are missing processors.CallsiteParameterAdder
     - structlog >=22.1
     - jinja2
   run_constrained:
-    - anthropic >=0.18.0,<0.19.0
-    - chromadb >=0.4.14,<0.5.0
+    - anthropic >=0.18.0,<1.0.0
+    - chromadb >=0.4.14,<0.5.0a0
     - fastembed >=0.2.0
     - qdrant-client >=1.6.2
-    - pinecone-client >=2.2.4,<2.3.0
-    - weaviate-client >=4.5.4,<4.6.0
-    - pymilvus >=2.3.7,<2.4.0
-    - boto3 >=1.34.78,<1.35.0
+    - pyepsilla >=0.3.7,<0.4.0a0
+    - pinecone-client >=2.2.4,<2.3.0a0
+    - weaviate-client >=4.5.4,<4.6.0a0
+    - pymilvus >=2.3.7,<2.4.0a0
+    - boto3 >=1.34.78,<1.35.0a0
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
-  skip: true  # [py<39 or py>311]
+  skip: true  # [py<39 or py>311 or s390x]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
-  skip: true  # [py<39 or py>311 or s390x or win]
+  skip: true  # [py<39 or py>311 or s390x]
 
 requirements:
   host:
@@ -53,7 +53,11 @@ test:
     - dspy
   commands:
     - pip check
-    - pytest -v
+    - pytest -vv tests  # [not win]
+    # skip test_multi_thread_evaluate_call_cancelled on win because
+    # it sends a SIGINT with os.kill(os.getpid(), signal.SIGINT) and
+    # makes the whole pytest quit.
+    - pytest -vv tests -k "not test_multi_thread_evaluate_call_cancelled"  # [win]
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,18 +10,20 @@ source:
   sha256: e0327376b135ff72b16c13c989aeb5f72e34f787381fe396520d3f99b67956e1
 
 build:
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  skip: true  # [py<39 or py>311]
 
 requirements:
   host:
-    - python >=3.9,<3.12
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.9,<3.12
-    - backoff ~=2.2.1
-    - joblib ~=1.3.2
+    - python
+    - backoff >=2.2.1,<2.3
+    - joblib >=1.3,<2.0
     - openai >=0.28.1,<2.0.0
     - pandas
     - regex
@@ -30,27 +32,33 @@ requirements:
     - datasets >=2.14.6,<3.0.0
     - requests
     - optuna
-    - pydantic ~=2.0
+    - pydantic >=2.0,<3.0
     - structlog
     - jinja2
   run_constrained:
-    - anthropic ~=0.18.0
-    - chromadb ~=0.4.14
+    - anthropic >=0.18.0,<0.19.0
+    - chromadb >=0.4.14,<0.5.0
     - fastembed >=0.2.0
-    - marqo *
     - qdrant-client >=1.6.2
-    - pinecone-client ~=2.2.4
-    - weaviate-client ~=4.5.4
-    - pymilvus ~=2.3.7
-    - boto3 ~=1.34.78
+    - pinecone-client >=2.2.4,<2.3.0
+    - weaviate-client >=4.5.4,<4.6.0
+    - pymilvus >=2.3.7,<2.4.0
+    - boto3 >=1.34.78,<1.35.0
 
 test:
+  source_files:
+    - tests
   imports:
     - dspy
   commands:
     - pip check
+    - pytest
   requires:
     - pip
+    - pytest
+    - pytest-mock
+    - pytorch
+    - transformers
 
 about:
   home: https://github.com/stanfordnlp/dspy
@@ -58,9 +66,11 @@ about:
   description: |
     DSPy: The framework for programming—not prompting—foundation models
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   doc_url: https://dspy-docs.vercel.app/
+  dev_url: https://github.com/stanfordnlp/dspy
 
 extra:
   recipe-maintainers:
-    - mukhery
+    - viridianmelody

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ test:
     - dspy
   commands:
     - pip check
-    - pytest
+    - pytest -v
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
-  skip: true  # [py<39 or py>311 or s390x]
+  skip: true  # [py<39 or py>311 or s390x or win]
 
 requirements:
   host:


### PR DESCRIPTION
dspy-ai 2.4.13 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5231]
- https://github.com/stanfordnlp/dspy/tree/2.4.13
- conda-forge: https://github.com/conda-forge/dspy-ai-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/dspy-ai/2.4.13
- pypi inspector: https://inspector.pypi.io/project/dspy-ai/2.4.13


### Depends on

- https://github.com/AnacondaRecipes/structlog-feedstock/pull/3

### Explanation of changes:
- Using staging channel for `structlog` until uploaded. 
- ~Windows tests are crashing without an error message, so I'm skipping it for the time being.~ fixed, `win` enabled with tests except one
- pinning of some dependencies from `pyproject.toml`, which differs from `requirements.txt` using `setup.py`



[PKG-5231]: https://anaconda.atlassian.net/browse/PKG-5231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ